### PR TITLE
Finalize CircleCI Integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,13 @@ jobs:
       - setup_remote_docker
       - run:
           name: Build Docker image
-          command: docker build -t mosquitto-unraid .
+          command: make mosquitto-unraid
+      - run:
+          name: Build Test image
+          command: make mosquitto-unraid-tests
       - run:
           name: Test Docker image
-          command: |
-            python3 -m venv .venv
-            source .venv/bin/activate
-            pip install -r tests/requirements.txt
-            mkdir -p test-results/docker
-            pytest --junit-xml=test-results/docker/results.xml tests/
+          command: make circleci-test
       - store_test_results:
           path: test-results
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+mosquitto-unraid
+mosquitto-unraid-tests
+
 *~
 *.swp
 .vs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+MKDIR_P := mkdir -p
+
+.PHONY: all clean images test circleci-test
+
+clean:
+	rm -f mosquitto-unraid mosquitto-unraid-test
+	docker image rm mosquitto-unraid
+	docker image rm mosquitto-unraid-tests
+
+images: mosquitto-unraid mosquitto-unraid-tests
+
+mosquitto-unraid: Dockerfile include_dir.conf docker-entrypoint.sh
+	docker build -t mosquitto-unraid . && touch mosquitto-unraid
+
+mosquitto-unraid-tests: tests/Dockerfile tests/requirements.txt tests/run_tests.sh tests/docker/*.py
+	docker build -t mosquitto-unraid-tests tests/ && touch mosquitto-unraid-tests
+
+test: mosquitto-unraid mosquitto-unraid-tests
+	$(MKDIR_P) test-results/docker
+	$(eval CONTAINER := $(shell docker create -v /var/run/docker.sock:/var/run/docker.sock mosquitto-unraid-tests))
+	docker start $(CONTAINER)
+	TEST_RC=$$(docker wait $(CONTAINER));\
+		docker logs $(CONTAINER);\
+		docker cp $(CONTAINER):/tests/test-results/docker/. test-results/docker/;\
+		docker rm $(CONTAINER);\
+		exit $$TEST_RC
+
+circleci-test: mosquitto-unraid mosquitto-unraid-tests
+	$(MKDIR_P) test-results/docker
+	$(eval CONTAINER := $(shell docker create -e DOCKER_HOST=$(DOCKER_HOST) -e DOCKER_CERT_PATH=$(DOCKER_CERT_PATH) -e DOCKER_MACHINE_NAME=$(DOCKER_MACHINE_NAME) -e DOCKER_TLS_VERIFY=$(DOCKER_TLS_VERIFY) -e NO_PROXY=$(NO_PROXY) mosquitto-unraid-tests))
+	docker cp $(DOCKER_CERT_PATH) $(CONTAINER):$(DOCKER_CERT_PATH)
+	docker inspect $(CONTAINER)
+	docker start $(CONTAINER)
+	TEST_RC=$$(docker wait $(CONTAINER));\
+		docker logs $(CONTAINER);\
+		docker cp $(CONTAINER):/tests/test-results/docker/. test-results/docker/;\
+		docker rm $(CONTAINER);\
+		exit $$TEST_RC

--- a/tests/.dockerignore
+++ b/tests/.dockerignore
@@ -1,0 +1,11 @@
+.git
+*.pyc
+*~
+
+Dockerfile
+.circleci
+
+__pycache__
+.pytest_cache
+.venv
+env/

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,13 @@
+FROM circleci/python:3.7.2
+
+USER root
+WORKDIR /tests
+
+COPY requirements.txt ./
+RUN pip install --upgrade pip \
+    && pip install -r requirements.txt
+
+COPY run_tests.sh /tests/
+COPY docker/* /tests/
+
+ENTRYPOINT [ "/bin/bash", "-c", "/tests/run_tests.sh" ]

--- a/tests/docker/mqtt_on_1885.conf
+++ b/tests/docker/mqtt_on_1885.conf
@@ -1,0 +1,2 @@
+port 1885
+protocol mqtt

--- a/tests/docker/test_basic.py
+++ b/tests/docker/test_basic.py
@@ -19,21 +19,7 @@ def test_basic_functionality(create_mosquitto_container):
     mosquitto = create_mosquitto_container()
 
     mosquitto.start()
-    mqtt_port = mosquitto.get_host_port(1883)
-    assert mqtt_port is not None
-
-    connection_rc = None
-    def on_connect(client, user_data, flags, rc):
-        nonlocal connection_rc
-        connection_rc = rc
-        client.disconnect()
-
-    client = mqtt.Client()
-    client.on_connect = on_connect
-    client.connect("127.0.0.1", port=mqtt_port)
-
-    timeout_time = datetime.now() + timedelta(seconds=5)
-    while datetime.now() < timeout_time and connection_rc is None:
-        client.loop()
-
-    assert connection_rc == 0
+    ran = False
+    with mosquitto.connect():
+        ran = True
+    assert ran

--- a/tests/docker/test_unraid_integrations.py
+++ b/tests/docker/test_unraid_integrations.py
@@ -1,4 +1,7 @@
+from datetime import timedelta
 from time import sleep
+import docker
+import os
 import pytest
 
 def test_creates_example_mosquitto_conf(create_mosquitto_container):
@@ -13,17 +16,35 @@ def test_creates_example_mosquitto_conf(create_mosquitto_container):
     mosquitto.wait()
 
     conf = mosquitto.get_file('/mosquitto/config/mosquitto.conf.example')
-    print(f'{conf[:100]}')
     assert len(conf) > 0
+    assert b'osquitto' in conf
 
-@pytest.mark.skip(reason='Not yet implemented')
-def test_uses_include_dir_by_default():
-    pass
+def test_uses_include_dir_by_default(create_mosquitto_container, tmpdir):
+    # Create mosquitto-unraid container with pre-injected mqtt_on_1885.conf file
+    # to exercies the built-in include_dir support for *.conf files
+    mosquitto = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_on_1885.conf': 'mqtt_on_1885.conf'
+            }
+        )
+    mosquitto.start()
 
-@pytest.mark.skip(reason='Not yet implemented')
+    # Ensure running on 1885 (mqtt_on_1885.conf)
+    connected = False
+    with mosquitto.connect(container_port=1885):
+        connected = True
+
+    # Ensure not running on 1883 (default)
+    with pytest.raises(ConnectionError):
+        with mosquitto.connect(container_port=1883, timeout=timedelta(seconds=1)):
+            assert False
+
+    assert connected
+
+@pytest.mark.skip(reason='Test not yet implemented')
 def test_container_includes_mosquitto_sub():
     pass
 
-@pytest.mark.skip(reason='Not yet implemented')
+@pytest.mark.skip(reason='Test not yet implemented')
 def test_container_includes_mosquitto_pub():
     pass

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+mkdir -p test-results/docker
+ls ${DOCKER_CERT_PATH}
+pytest --junit-xml=test-results/docker/results.xml ./


### PR DESCRIPTION
Bring CircleCI online with container-level tests for basic functionality.

Specific tests:
- Basic functionality (can connect to container with paho-mqtt)
- `include_dir` support (dropping a new `.conf` file in `/mosquitto/config` is picked up and modifies default behavior)
- Container command can be overridden, e.g. `docker run --rm -it cmccambridge/mosquitto-unraid /bin/bash`.  Prerequisite for #2.
