### PR TITLE
Update to v1.6.2 and add CLI pub/sub tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-mosquitto:1.5.8
+FROM eclipse-mosquitto:1.6.2
 
 RUN cp /mosquitto/config/mosquitto.conf /mosquitto/mosquitto.conf.example
 COPY docker-entrypoint.sh /

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This container is a minimal port of the official [Eclipse Mosquitto][eclipse-mos
 * [Ports](#ports)
 * [Configuration](#configuration)
 * [Advanced Configuration](#advanced-configuration)
+* [Command Line MQTT Clients](#command-line-mqtt-clients)
 * [unRAID Integration](#unraid-integration)
 
 [eclipse-mosquitto]: https://mosquitto.org
@@ -154,6 +155,23 @@ _In the meantime, consult the [official documentation][official-docs]_
 TODO
 
 _In the meantime, consult the [official documentation][official-docs]_
+
+## Command Line MQTT Clients
+
+For convenience of testing MQTT environments, this container includes the command-line interface tools `mosquitto_sub` and `mosquitto_pub`. You can find the details of their usage in their respective man pages ([`mosquitto_sub`][man-mosquitto_sub], [`mosquitto_pub`][man-mosquitto_pub]), but here are some quick examples:
+
+Use `mosquitto_sub` in a new container to subscribe to an MQTT topic `$MQTT_TOPIC` on a remote host `$MQTT_HOST`:
+```
+docker run --rm -it mosquitto-unraid mosquitto_sub -h ${MQTT_HOST} -p 1883 -t ${MQTT_TOPIC}
+```
+
+Use `mosquitto_pub` to publish a message `$MQTT_MESSAGE` to an MQTT topic `$MQTT_TOPIC` on the mosquitto instance in an _existing_ running `mosquitto-unraid` container named `$CONTAINER`:
+```
+docker exec -it ${CONTAINER} mosquitto_pub -h 127.0.0.1 -p 1883 -t ${MQTT_TOPIC} -m ${MQTT_MESSAGE}
+```
+
+[man-mosquitto_sub]: https://mosquitto.org/man/mosquitto_sub-1.html
+[man-mosquitto_pub]: https://mosquitto.org/man/mosquitto_pub-1.html
 
 ## unRAID Integration
 

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -82,6 +82,9 @@ class MosquittoContainerHelper:
     def stop(self):
         return self.container.stop()
 
+    def exec_run(self, **kwargs):
+        return self.container.exec_run(**kwargs)
+
     def logs(self):
         return self.container.logs()
 

--- a/tests/docker/test_basic.py
+++ b/tests/docker/test_basic.py
@@ -24,20 +24,28 @@ def test_basic_functionality(create_mosquitto_container):
         ran = True
     assert ran
 
-def test_container_includes_mosquitto_sub(create_mosquitto_container):
-    mosquitto_sub = create_mosquitto_container(command='/usr/bin/mosquitto_sub --help')
-    mosquitto_sub.start()
-    mosquitto_sub.wait()
+def run_once(create_mosquitto_container, command):
+    mosquitto = create_mosquitto_container(command=command)
+    mosquitto.start()
+    mosquitto.wait()
+    return mosquitto.logs()
 
-    logs = mosquitto_sub.logs()
+def test_container_includes_mosquitto_sub(create_mosquitto_container):
+    logs = run_once(create_mosquitto_container, command='/usr/bin/mosquitto_sub --help')
+    assert b'mqtt' in logs
+    assert b'mosquitto_sub version' in logs
+
+def test_container_runs_mosquitto_sub_from_PATH(create_mosquitto_container):
+    logs = run_once(create_mosquitto_container, command='mosquitto_sub --help')
     assert b'mqtt' in logs
     assert b'mosquitto_sub version' in logs
 
 def test_container_includes_mosquitto_pub(create_mosquitto_container):
-    mosquitto_pub = create_mosquitto_container(command='/usr/bin/mosquitto_pub --help')
-    mosquitto_pub.start()
-    mosquitto_pub.wait()
+    logs = run_once(create_mosquitto_container, command='/usr/bin/mosquitto_pub --help')
+    assert b'mqtt' in logs
+    assert b'mosquitto_pub version' in logs
 
-    logs = mosquitto_pub.logs()
+def test_container_runs_mosquitto_pub_from_PATH(create_mosquitto_container):
+    logs = run_once(create_mosquitto_container, command='mosquitto_pub --help')
     assert b'mqtt' in logs
     assert b'mosquitto_pub version' in logs

--- a/tests/docker/test_basic.py
+++ b/tests/docker/test_basic.py
@@ -23,3 +23,21 @@ def test_basic_functionality(create_mosquitto_container):
     with mosquitto.connect():
         ran = True
     assert ran
+
+def test_container_includes_mosquitto_sub(create_mosquitto_container):
+    mosquitto_sub = create_mosquitto_container(command='/usr/bin/mosquitto_sub --help')
+    mosquitto_sub.start()
+    mosquitto_sub.wait()
+
+    logs = mosquitto_sub.logs()
+    assert b'mqtt' in logs
+    assert b'mosquitto_sub version' in logs
+
+def test_container_includes_mosquitto_pub(create_mosquitto_container):
+    mosquitto_pub = create_mosquitto_container(command='/usr/bin/mosquitto_pub --help')
+    mosquitto_pub.start()
+    mosquitto_pub.wait()
+
+    logs = mosquitto_pub.logs()
+    assert b'mqtt' in logs
+    assert b'mosquitto_pub version' in logs

--- a/tests/docker/test_unraid_integrations.py
+++ b/tests/docker/test_unraid_integrations.py
@@ -60,3 +60,24 @@ def test_end_to_end_pub_sub_cli(create_mosquitto_container):
 
     # Inspect subscriber's logs, expecting to see the message from the publisher
     assert message in sub.logs()
+
+def test_end_to_end_pub_sub_cli_single_container(create_mosquitto_container):
+    # Create an MQTT server on dfeault port 1883
+    mosquitto = create_mosquitto_container()
+    mosquitto.start()
+
+    # Create an MQTT subscriber listening up to 30 seconds for 1 message on /test/topic
+    (sub_rc, sub_logs) = mosquitto.exec_run(
+        cmd=f'/usr/bin/mosquitto_sub -h 127.0.0.1 -p 1883 -t /test/topic -C 1 -W 30',
+        stream=True
+        )
+
+    # Finally, use an MQTT publisher to push a message to /test/topic
+    message = b'mqtt_test_mesage'
+    (pub_rc, pub_logs) = mosquitto.exec_run(
+        cmd=f'/usr/bin/mosquitto_pub -h 127.0.0.1 -p 1883 -t /test/topic -m \'f{message}\'',
+        stream=True
+        )
+
+    # Inspect subscriber's logs, expecting to see the message from the publisher
+    assert any(message in line for line in sub_logs)


### PR DESCRIPTION
Changes in this PR:
* Update to latest upstream version: 1.6.2. This closes #3.
* Add tests for `mosquitto_sub` and `mosquitto_pub`, which the upstream version now includes. The tests will be sure this never regresses in future updates. This closes #2.