### PR TITLE
Update to new generation CircleCI docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   build_test:
     docker:
-      - image: circleci/python:3.7.2
+      - image: cimg/python:3.8
 
     steps:
       - checkout
@@ -35,7 +35,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.7.2
+      - image: cimg/python:3.8
     steps:
       - setup_remote_docker
       - attach_workspace:

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/python:3.7.2
+FROM cimg/python:3.8
 
 USER root
 WORKDIR /tests


### PR DESCRIPTION
Per CircleCI announcements, legacy `circleci/python` images are being descaled in favor of newer base images.

Migrating to `cimg/python` for this application.