### PR TITLE
Authenticate CircleCI docker pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,6 @@ jobs:
           command: |
             echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USER --password-stdin
       - run:
-          name: Test Docker Login
-          command: docker login
-      - run:
           name: Build Docker image
           command: make mosquitto-unraid
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,19 @@ jobs:
   build_test:
     docker:
       - image: cimg/python:3.8
-
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - setup_remote_docker
+      - run:
+          name: Login to Docker within Executor
+          command: |
+            echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USER --password-stdin
+      - run:
+          name: Test Docker Login
+          command: docker login
       - run:
           name: Build Docker image
           command: make mosquitto-unraid
@@ -36,6 +45,9 @@ jobs:
   deploy:
     docker:
       - image: cimg/python:3.8
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
     steps:
       - setup_remote_docker
       - attach_workspace:


### PR DESCRIPTION
Avoid Docker Hub rate limits by authenticating docker executor.