### PR TITLE
Support upstream 2.x series

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM eclipse-mosquitto:2.0.3
 LABEL maintainer="Colin McCambridge <colin@mccambridge.org>" \
     description="mosquitto-unraid: Eclipse Mosquitto Broker tweaked for unRAID"
 
-RUN cp /mosquitto/config/mosquitto.conf /mosquitto/mosquitto.conf.example
 COPY docker-entrypoint.sh /
-COPY include_dir.conf /mosquitto/include_dir.conf
+COPY *.conf /mosquitto-unraid/
+RUN cp /mosquitto/config/mosquitto.conf /mosquitto-unraid/mosquitto.conf.example
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM eclipse-mosquitto:1.6.12
+FROM eclipse-mosquitto:2.0.3
+
+LABEL maintainer="Colin McCambridge <colin@mccambridge.org>" \
+    description="mosquitto-unraid: Eclipse Mosquitto Broker tweaked for unRAID"
 
 RUN cp /mosquitto/config/mosquitto.conf /mosquitto/mosquitto.conf.example
 COPY docker-entrypoint.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-mosquitto:2.0.4
+FROM eclipse-mosquitto:2.0.5
 
 LABEL maintainer="Colin McCambridge <colin@mccambridge.org>" \
     description="mosquitto-unraid: Eclipse Mosquitto Broker tweaked for unRAID"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-mosquitto:2.0.3
+FROM eclipse-mosquitto:2.0.4
 
 LABEL maintainer="Colin McCambridge <colin@mccambridge.org>" \
     description="mosquitto-unraid: Eclipse Mosquitto Broker tweaked for unRAID"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean:
 
 images: mosquitto-unraid mosquitto-unraid-tests
 
-mosquitto-unraid: Dockerfile include_dir.conf docker-entrypoint.sh
+mosquitto-unraid: Dockerfile *.conf docker-entrypoint.sh
 	docker build -t mosquitto-unraid . && touch mosquitto-unraid
 
 mosquitto-unraid-tests: tests/Dockerfile tests/requirements.txt tests/run_tests.sh tests/docker/*.py

--- a/TODO.todo
+++ b/TODO.todo
@@ -1,0 +1,9 @@
+2.x Migration:
+    ✔ Migration support @done(21-01-19 22:16)
+    ✔ Migration end-to-end testing @done(21-01-19 22:16)
+    ✔ Test 2.0.5 @done(21-01-19 22:20)
+    ☐ Update README
+    ☐ Update template with new RUN_INSECURE_MQTT_SERVER parameter
+    ☐ Test template update end-to-end (without new Docker image - just variable)
+    ☐ Post in support thread
+    ☐ Deploy update

--- a/TODO.todo
+++ b/TODO.todo
@@ -2,8 +2,8 @@
     ✔ Migration support @done(21-01-19 22:16)
     ✔ Migration end-to-end testing @done(21-01-19 22:16)
     ✔ Test 2.0.5 @done(21-01-19 22:20)
-    ☐ Update README
-    ☐ Update template with new RUN_INSECURE_MQTT_SERVER parameter
-    ☐ Test template update end-to-end (without new Docker image - just variable)
-    ☐ Post in support thread
-    ☐ Deploy update
+    ✔ Update README @done(21-01-19 23:29)
+    ✔ Update template with new RUN_INSECURE_MQTT_SERVER parameter @done(21-01-19 23:52)
+    ✔ Test template update end-to-end (without new Docker image - just variable) @done(21-01-19 23:52)
+    ✔ Post in support thread @done(21-01-20 00:04)
+    ✔ Deploy update @done(21-01-20 00:12)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,18 +3,61 @@ set -e
 
 populate_defaults() {
     if [[ ! -f /mosquitto/config/mosquitto.conf.example ]]; then
-        cp /mosquitto/mosquitto.conf.example /mosquitto/config/
+        cp /mosquitto-unraid/mosquitto.conf.example /mosquitto/config/
+    fi
+}
+
+mosquitto_1_to_2_migration() {
+    # If the user doesn't already have a copy of the mosquitto-unraid default
+    # config file, create it now.
+    # NOTE: The default file does NOTHING until the user uncomments lines.
+    if [[ ! -f /mosquitto/config/mosquitto-unraid-default.conf ]]; then
+        cp /mosquitto-unraid/mosquitto-unraid-default.conf /mosquitto/config/
+    fi
+
+    # We presume the standard include_dir.conf unless overridden to the
+    # insecure version below
+    MOSQUITTO_CONFIG_FILE="/mosquitto-unraid/include_dir.conf"
+
+    # Verify that the user has a configured listener, and appears to be
+    # compliant with the Mosquitto 2.0 migration requirements
+    if ! grep -q -E "^\s*(listener|port)\s+\d+" /mosquitto/config/*.conf ; then
+
+        # Check for user override via environment variable
+        if [[ "${RUN_INSECURE_MQTT_SERVER}" == 1 ]]; then
+            echo "RUN_INSECURE_MQTT_SERVER = 1. Using insecure MQTT listener settings:"
+            echo "Bind port 1883 on all interfaces, and allow anonymous connections."
+            MOSQUITTO_CONFIG_FILE="/mosquitto-unraid/include_dir_and_insecure_listener.conf"
+        else
+            echo "!! ATTENTION: MANUAL CONFIGURATION IS REQUIRED !!"
+            echo
+            echo "Due to security hardening in Mosquitto 2.0, you MUST TAKE MANUAL ACTION to"
+            echo "reenable MQTT in this container!"
+            echo
+            echo "OPTION 1: Set RUN_INSECURE_MQTT_SERVER to 1 in this container's settings"
+            echo
+            echo "OPTION 2: Edit the file \"mosquitto-unraid-default.conf\" in your configuration"
+            echo "path for more details (Usually /mnt/user/appdata/mosquitto)"
+            echo
+            echo "OPTION 3: Update your customized Mosquitto configuration to configure at"
+            echo "least one listener. See https://mosquitto.org/documentation/migrating-to-2-0/"
+
+            # We will NOT launch this container until the user manually migrates
+            # or overrides this security step with RUN_UN==INSECURE_MQTT_SERVER=1
+            exit 1
+        fi
     fi
 }
 
 initialize() {
     populate_defaults
+    mosquitto_1_to_2_migration
 }
 
 if [[ "$1" == "mosquitto" ]]; then
     initialize
 
-    exec /usr/sbin/mosquitto -c /mosquitto/include_dir.conf
+    exec /usr/sbin/mosquitto -c ${MOSQUITTO_CONFIG_FILE}
 fi
 
 exec "$@"

--- a/include_dir_and_insecure_listener.conf
+++ b/include_dir_and_insecure_listener.conf
@@ -1,0 +1,12 @@
+# This INSECURE minimal mosquitto.conf file starts a default listener
+# on port 1883 allowing anonymous connections as was standard in
+# Mosquitto 1.x versions.
+
+# It defers 100% of the remaining configuration to the files mapped
+# into the container at /mosquitto/config/*.conf
+
+listener 1883
+protocol mqtt
+allow_anonymous true
+
+include_dir /mosquitto/config

--- a/mosquitto-unraid-default.conf
+++ b/mosquitto-unraid-default.conf
@@ -1,0 +1,30 @@
+# mosquitto-unraid DEFAULT CONFIGURATION
+
+# !! You MUST edit this file, or set RUN_INSECURE_MQTT_SERVER=1 !!
+
+# Choose one of the options below to enable, or learn the details of Mosquitto
+# configuration and write your own configuration file:
+# 1. Mosquitto 2.0: https://mosquitto.org/blog/2020/12/version-2-0-0-released/
+# 2. Migration guide: https://mosquitto.org/documentation/migrating-to-2-0/
+
+# OPTION 1: Insecure listener restoring Mosquitto 1.x behavior
+
+# These are the same settings that will be in effect if you run the container
+# with RUN_INSECURE_MQTT_SERVER = 1 in the environment. They match the settings
+# from pre-2.0, i.e. MQTT protocol on port 1883 on all interfaces, permitting
+# anonymous connections. To enable this configuration, remove the # characters
+# from the start of the next 3 lines to uncomment them:
+#listener 1883
+#protocol mqtt
+#allow_anonymous true
+
+# OPTION 2: Enable a listener on the standard port, and use a password file
+
+# 1. Uncomment the following block to enable a standard port 1883 MQTT listener,
+#    and require password authentication.
+# 2. Follow the instructions on the mosquitto-unraid README to create users and
+#    set their passwords:
+#    https://github.com/cmccambridge/mosquitto-unraid/blob/master/README.md#Authentication
+#listener 1883
+#protocol mqtt
+#password_file /mosquitto/config/passwd

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -64,8 +64,14 @@ def create_container(request, create_volume):
 def create_tar_archive(filespecs):
     tar_stream = BytesIO()
     with tarfile.open(fileobj=tar_stream, mode='w') as tar:
-        for archive_name, local_path in filespecs.items():
-            tar.add(name=local_path, arcname=archive_name)
+        for archive_name, source in filespecs.items():
+            if isinstance(source, str):
+                tar.add(name=source, arcname=archive_name)
+            else:
+                # Assume BytesIO-like object
+                tarinfo = tarfile.TarInfo(archive_name)
+                tarinfo.size = len(source.getvalue())
+                tar.addfile(tarinfo, fileobj=source)
     tar_stream.seek(0)
     return tar_stream
 

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -99,7 +99,9 @@ class MosquittoContainerHelper:
             self,
             container_port=1883,
             protocol='tcp',
-            timeout=timedelta(seconds=5)
+            timeout=timedelta(seconds=5),
+            username=None,
+            password=None
             ):
         container_host = self.get_container_ip()
 
@@ -110,6 +112,8 @@ class MosquittoContainerHelper:
 
         client = mqtt.Client()
         client.on_connect = _on_connect
+        if username or password:
+            client.username_pw_set(username, password)
         client.connect(container_host, port=container_port)
 
         try:

--- a/tests/docker/mqtt_default_listener.conf
+++ b/tests/docker/mqtt_default_listener.conf
@@ -1,0 +1,3 @@
+port 1883
+protocol mqtt
+allow_anonymous true

--- a/tests/docker/mqtt_on_1883.conf
+++ b/tests/docker/mqtt_on_1883.conf
@@ -1,3 +1,3 @@
-listener 1885
+listener 1883
 protocol mqtt
 allow_anonymous true

--- a/tests/docker/test_1_x_to_2_0_migration.py
+++ b/tests/docker/test_1_x_to_2_0_migration.py
@@ -1,0 +1,229 @@
+import re
+from io import BytesIO
+from time import sleep
+
+import pytest
+
+def test_container_dies_with_message_and_unraid_config_if_unmigrated(create_mosquitto_container):
+    mosquitto = create_mosquitto_container()
+    mosquitto.start()
+
+    # Expect container to exit promptly, without explicit termination
+    mosquitto.wait()
+    assert b'MANUAL CONFIGURATION IS REQUIRED' in mosquitto.logs()
+
+    conf = mosquitto.get_file('/mosquitto/config/mosquitto-unraid-default.conf')
+    assert len(conf) > 0
+    assert b'mosquitto-unraid' in conf
+
+
+def test_creates_unraid_default_conf_if_migrated_but_missing(create_mosquitto_container):
+    mosquitto = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_on_1883.conf': 'mqtt_on_1883.conf'
+            }
+        )
+    mosquitto.start()
+
+    # Ensure container is up and running
+    with mosquitto.connect() as client:
+        client.disconnect()
+
+    mosquitto.stop()
+    mosquitto.wait()
+
+    conf = mosquitto.get_file('/mosquitto/config/mosquitto-unraid-default.conf')
+    assert len(conf) > 0
+    assert b'mosquitto-unraid' in conf
+    
+
+def test_does_not_overwrite_unraid_default_conf_if_present(create_mosquitto_container):
+    # Pre-populate mosquitto-unraid-default.conf with a customized file
+    mosquitto = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mosquitto-unraid-default.conf': 'mqtt_on_1885.conf'
+            }
+        )
+    mosquitto.start()
+
+    # Ensure container is up and running
+    with mosquitto.connect(container_port=1885) as client:
+        client.disconnect()
+
+    mosquitto.stop()
+    mosquitto.wait()
+
+    conf = mosquitto.get_file('/mosquitto/config/mosquitto-unraid-default.conf')
+    assert len(conf) > 0
+    assert b'mosquitto-unraid' not in conf
+    assert b'1885' in conf
+
+
+def test_uses_insecure_default_if_override_env_var_set_properly(create_mosquitto_container):
+    mosquitto_noenv = create_mosquitto_container()
+    mosquitto_noenv.start()
+
+    # Expect container to exit promptly, without explicit termination
+    mosquitto_noenv.wait()
+    assert b'MANUAL CONFIGURATION IS REQUIRED' in mosquitto_noenv.logs()
+    assert b'Using insecure' not in mosquitto_noenv.logs()
+
+    mosquitto_env = create_mosquitto_container(environment={"RUN_INSECURE_MQTT_SERVER": 1})
+    mosquitto_env.start()
+
+    # Ensure container is up and running
+    with mosquitto_env.connect() as client:
+        client.disconnect()
+
+    mosquitto_env.stop()
+    mosquitto_env.wait()
+
+    assert b'Using insecure' in mosquitto_env.logs()
+
+
+def test_no_insecure_default_if_override_env_var_set_wrong(create_mosquitto_container):
+    mosquitto_wrong = create_mosquitto_container(environment={"RUN_INSECURE_MQTT_SERVER": 0})
+    mosquitto_empty = create_mosquitto_container(environment={"RUN_INSECURE_MQTT_SERVER": 0})
+    mosquitto_wrong.start()
+    mosquitto_empty.start()
+
+    # Expect container to exit promptly, without explicit termination
+    mosquitto_wrong.wait()
+    mosquitto_empty.wait()
+    assert b'MANUAL CONFIGURATION IS REQUIRED' in mosquitto_wrong.logs()
+    assert b'MANUAL CONFIGURATION IS REQUIRED' in mosquitto_empty.logs()
+
+
+def test_uses_migrated_config_if_listener_configured(create_mosquitto_container):
+    mosquitto = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_on_1885.conf': 'mqtt_on_1885.conf'
+            }
+        )
+    mosquitto_env = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_on_1885.conf': 'mqtt_on_1885.conf'
+            },
+        environment={'RUN_INSECURE_MQTT_SERVER': 1}
+        )
+
+    # Ensure running on 1885 (mqtt_on_1885.conf)
+    connected = 0
+    for mq in [mosquitto, mosquitto_env]:
+        mq.start()
+
+        with mq.connect(container_port=1885):
+            connected += 1
+        mq.stop()
+        mq.wait()
+
+        assert b'Using insecure' not in mq.logs()
+        assert b'include_dir.conf' in mq.logs()
+
+    assert connected == 2
+
+
+def test_uses_migrated_config_if_default_listener_configured(create_mosquitto_container):
+    mosquitto = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_default_listener.conf': 'mqtt_default_listener.conf'
+            }
+        )
+    mosquitto_env = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_default_listener.conf': 'mqtt_default_listener.conf'
+            },
+        environment={'RUN_INSECURE_MQTT_SERVER': 1}
+        )
+
+    connected = 0
+    for mq in [mosquitto, mosquitto_env]:
+        mq.start()
+        
+        with mq.connect():
+            connected += 1
+        mq.stop()
+        mq.wait()
+
+        assert b'Using insecure' not in mq.logs()
+        assert b'include_dir.conf' in mq.logs()
+
+    assert connected == 2
+
+
+def enable_config_options(conf_file, option_number):
+    cur_option = 0
+    if isinstance(conf_file, bytes):
+        conf_file = conf_file.decode('utf-8')
+    result = ''
+    for line in conf_file.split('\n'):
+        if m := re.match(r'# OPTION (\d+):.*', line):
+            cur_option = int(m.group(1))
+        if cur_option == option_number and (m := re.match(r'#(\S.*)', line)):
+            line = m.group(1)
+        result += f'{line}\n'
+    return result
+
+
+def test_default_config_option_1_sets_up_anonymous_listener(create_mosquitto_container):
+    # 1. Create container without any configuration to generate default
+    mosquitto = create_mosquitto_container()
+    mosquitto.start()
+    mosquitto.wait()
+    assert b'MANUAL CONFIGURATION IS REQUIRED' in mosquitto.logs()
+
+    # 2. Extract the default config file and edit
+    conf = mosquitto.get_file('/mosquitto/config/mosquitto-unraid-default.conf')
+    conf = enable_config_options(conf, 1)
+    print(conf)
+
+    # 3. Reinject the edited config
+    mosquitto.put_files({
+        '/mosquitto/config/mosquitto-unraid-default.conf': BytesIO(conf.encode('utf-8'))
+        })
+
+    # 4. Start the container and expect it to accept connections
+    mosquitto.start()
+    with mosquitto.connect() as client:
+        client.disconnect()
+
+
+def test_default_config_option_2_sets_up_password_listener(create_mosquitto_container):
+    # single container, create passwd, user, connect with auth
+    # 1. Create container without any configuration to generate default
+    mosquitto = create_mosquitto_container()
+    mosquitto.start()
+    mosquitto.wait()
+    assert b'MANUAL CONFIGURATION IS REQUIRED' in mosquitto.logs()
+
+    # 2. Extract the default config file and edit to enable option 2: password_file
+    conf = mosquitto.get_file('/mosquitto/config/mosquitto-unraid-default.conf')
+    conf = enable_config_options(conf, 2)
+    print(conf)
+
+    # 3. Reinject the edited config and an empty initial password file
+    mosquitto.put_files({
+        '/mosquitto/config/mosquitto-unraid-default.conf': BytesIO(conf.encode('utf-8')),
+        '/mosquitto/config/passwd': BytesIO(b'')
+        })
+
+    # 4. Start the container, create a password file, and signal Mosquitto to reload it
+    mosquitto.start()
+    USER = 'user1'
+    PASSWORD = 'password1'
+    mosquitto.exec_run(cmd=f'mosquitto_passwd -c -b /mosquitto/config/passwd {USER} {PASSWORD}')
+    mosquitto.exec_run(cmd='killall -SIGHUP mosquitto')
+
+    # 5. Expect anonymous connection to be REJECTED
+    with pytest.raises(ConnectionError):
+        with mosquitto.connect():
+            assert False
+    
+    # 6. Expect incorrect user/password to be REJECTED
+    with pytest.raises(ConnectionError):
+        with mosquitto.connect(username=f'x{USER}x', password=f'no{PASSWORD}'):
+            assert False
+    
+    # 7. Expect correct user/password to be accepted
+    with mosquitto.connect(username=USER, password=PASSWORD) as client:
+        client.disconnect()

--- a/tests/docker/test_basic.py
+++ b/tests/docker/test_basic.py
@@ -16,7 +16,11 @@ def test_allows_cmd_override(create_mosquitto_container):
     assert any(b'hellopytest' in line for line in mosquitto.logs().splitlines())
 
 def test_basic_functionality(create_mosquitto_container):
-    mosquitto = create_mosquitto_container()
+    mosquitto = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_on_1883.conf': 'mqtt_on_1883.conf'
+            }
+        )
 
     mosquitto.start()
     ran = False

--- a/tests/docker/test_unraid_integrations.py
+++ b/tests/docker/test_unraid_integrations.py
@@ -5,7 +5,11 @@ import os
 import pytest
 
 def test_creates_example_mosquitto_conf(create_mosquitto_container):
-    mosquitto = create_mosquitto_container()
+    mosquitto = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_on_1883.conf': 'mqtt_on_1883.conf'
+            }
+        )
     mosquitto.start()
 
     # Ensure container is up and running
@@ -42,8 +46,12 @@ def test_uses_include_dir_by_default(create_mosquitto_container, tmpdir):
     assert connected
 
 def test_end_to_end_pub_sub_cli(create_mosquitto_container):
-    # Create an MQTT server on dfeault port 1883
-    server = create_mosquitto_container()
+    # Create an MQTT server on default port 1883
+    server = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_on_1883.conf': 'mqtt_on_1883.conf'
+            }
+        )
     server.start()
 
     # Create an MQTT subscriber listening up to 30 seconds for 1 message on /test/topic
@@ -63,7 +71,11 @@ def test_end_to_end_pub_sub_cli(create_mosquitto_container):
 
 def test_end_to_end_pub_sub_cli_single_container(create_mosquitto_container):
     # Create an MQTT server on dfeault port 1883
-    mosquitto = create_mosquitto_container()
+    mosquitto = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_on_1883.conf': 'mqtt_on_1883.conf'
+            }
+        )
     mosquitto.start()
 
     # Create an MQTT subscriber listening up to 30 seconds for 1 message on /test/topic

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-docker~=3.7.2
-paho-mqtt~=1.4.0
-plumbum~=1.6.7
-pytest~=4.4.1
+docker~=4.4.0
+paho-mqtt~=1.5.1
+plumbum~=1.6.9
+pytest~=6.2.1


### PR DESCRIPTION
Major breaking changes from upstream:
* Starting with Mosquitto 2.0, the default configuration will *only* bind to loop back addresses
* Starting with Mosquitto 2.0, no configuration *except* the loopback-only one will allow anonymous connections unless explicitly configured to do so.

In other words: Starting with Mosquitto 2.0, users must make an *explicit* choice to expose the MQTT server to beyond the local host.

This container will respect that change in security posture, while maintaining some unRAID ease-of-use, by implementing the following in this PR:

- [x] Detect that a user has not performed any explicit listener configuration and exit the container with an error code
- [x] Provide two easy-to-use default security choices, including a legacy-style "expose MQTT server for anonymous login on port 1883" and a simple password file based authenticated configuration, but require the user to explicitly configure either option.
- [x] Provide an environment variable `RUN_INSECURE_MQTT_SERVER` to select the legacy behavior in a single step. This will not be set by default, but is easy to add via unRAID.
- [x] Update the README to reflect these changes
- [x] Update the unRAID template to expose (but not set) the single-step legacy option