### PR TITLE
Support timezones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM eclipse-mosquitto:2.0.14
 LABEL maintainer="Colin McCambridge <colin@mccambridge.org>" \
     description="mosquitto-unraid: Eclipse Mosquitto Broker tweaked for unRAID"
 
+RUN apk add --no-cache \
+        tzdata
+
 COPY docker-entrypoint.sh /
 COPY *.conf /mosquitto-unraid/
 RUN cp /mosquitto/config/mosquitto.conf /mosquitto-unraid/mosquitto.conf.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-mosquitto:2.0.13
+FROM eclipse-mosquitto:2.0.14
 
 LABEL maintainer="Colin McCambridge <colin@mccambridge.org>" \
     description="mosquitto-unraid: Eclipse Mosquitto Broker tweaked for unRAID"

--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ The Eclipse Mosquitto logo
 
 ## CHANGELOG <a name="changelog"></a>
 
+**2.0.14 (2022-08-04)**
+* ⬆️ Upgrade to [upstream 2.0.14 release](http://mosquitto.org/blog/2021/11/version-2-0-14-released/)
+    * No security fixes in this release.
+
 **2.0.13 (2021-11-09)**
 * Upgrade to [upstream 2.0.13 release](https://mosquitto.org/blog/2021/10/version-2-0-13-released/)
 * Includes [2.0.12 updates](https://mosquitto.org/blog/2021/08/version-2-0-12-released/)

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ The Eclipse Mosquitto logo
 **2.0.14 (2022-08-04)**
 * ⬆️ Upgrade to [upstream 2.0.14 release](http://mosquitto.org/blog/2021/11/version-2-0-14-released/)
     * No security fixes in this release.
+* 🐛 Enable timezone awareness in the container. Thanks @askibit!
 
 **2.0.13 (2021-11-09)**
 * Upgrade to [upstream 2.0.13 release](https://mosquitto.org/blog/2021/10/version-2-0-13-released/)

--- a/tests/docker/log_timestamps.conf
+++ b/tests/docker/log_timestamps.conf
@@ -1,0 +1,1 @@
+log_timestamp_format %Y-%m-%dT%H:%M:%S@@Z%z@@

--- a/tests/docker/test_timezone.py
+++ b/tests/docker/test_timezone.py
@@ -1,0 +1,38 @@
+def test_default_timezone_is_utc(create_mosquitto_container):
+    mosquitto = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_on_1883.conf': 'mqtt_on_1883.conf',
+            '/mosquitto/config/log_timestamps.conf': 'log_timestamps.conf'
+            }
+        )
+    mosquitto.start()
+
+    # Ensure container is up, running, and logging messages
+    with mosquitto.connect() as client:
+        client.disconnect()
+
+    mosquitto.stop()
+    mosquitto.wait()
+
+    assert b'@@Z+0000@@' in mosquitto.logs()
+
+def test_timzeone_can_be_overridden(create_mosquitto_container):
+    mosquitto = create_mosquitto_container(
+        initial_filespecs={
+            '/mosquitto/config/mqtt_on_1883.conf': 'mqtt_on_1883.conf',
+            '/mosquitto/config/log_timestamps.conf': 'log_timestamps.conf'
+            },
+        environment={
+            'TZ': 'US/Hawaii'  # NB: Constant UTC-10 offset due to no DST
+        }
+        )
+    mosquitto.start()
+
+    # Ensure container is up, running, and logging messages
+    with mosquitto.connect() as client:
+        client.disconnect()
+
+    mosquitto.stop()
+    mosquitto.wait()
+
+    assert b'@@Z-1000@@' in mosquitto.logs()


### PR DESCRIPTION
Fixes #26 by adding `tzdata` to the docker image.

Add unit tests for the same.